### PR TITLE
Store connector refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Receipt manager
 
-This app uses the APIs that Lidl and Albert Heijn's apps also use to fetch your digital receipts. You log in with your store account(s).
+This app uses the APIs that Lidl and Albert Heijn's apps also use to fetch your digital receipts. You log in with your store account(s). Multiple accounts per store are supported.
 
 You can select purchased items to copy their total cost or add them to WieBetaaltWat/Splitser if logged in.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
 dependencies {
 
     implementation 'com.github.franmontiel:PersistentCookieJar:v1.0.1'
+    implementation 'androidx.room:room-runtime:2.5.2'
 
 //    implementation 'androidx.core:core-ktx:+'
     def composeBom = platform('androidx.compose:compose-bom:2023.04.01')

--- a/app/schemas/zip.zaop.paylink.database.ReceiptsDatabase/10.json
+++ b/app/schemas/zip.zaop.paylink.database.ReceiptsDatabase/10.json
@@ -1,0 +1,278 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 10,
+    "identityHash": "9572833fcc7d943513978228390cb67c",
+    "entities": [
+      {
+        "tableName": "receipt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `store_provided_id` TEXT NOT NULL, `account_id` INTEGER NOT NULL DEFAULT 0, `date` TEXT NOT NULL, `store` TEXT NOT NULL, `total_amount` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeProvidedId",
+            "columnName": "store_provided_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "account_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "store",
+            "columnName": "store",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalAmount",
+            "columnName": "total_amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_receipt_store_store_provided_id",
+            "unique": true,
+            "columnNames": [
+              "store",
+              "store_provided_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_receipt_store_store_provided_id` ON `${TABLE_NAME}` (`store`, `store_provided_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "receipt_item",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`item_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `index_inside_receipt` INTEGER NOT NULL, `receipt_id` INTEGER NOT NULL, `unit_price` INTEGER NOT NULL, `quantity` REAL NOT NULL, `store_provided_item_code` TEXT, `description` TEXT NOT NULL, `total_price` INTEGER NOT NULL, `total_discount` INTEGER NOT NULL DEFAULT 0, `has_been_sent_to_wbw` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "item_id",
+            "columnName": "item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "indexInsideReceipt",
+            "columnName": "index_inside_receipt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receiptId",
+            "columnName": "receipt_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitPrice",
+            "columnName": "unit_price",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quantity",
+            "columnName": "quantity",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeProvidedItemCode",
+            "columnName": "store_provided_item_code",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPrice",
+            "columnName": "total_price",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalDiscount",
+            "columnName": "total_discount",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hasBeenSentToWbw",
+            "columnName": "has_been_sent_to_wbw",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "item_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_receipt_item_receipt_id_index_inside_receipt",
+            "unique": true,
+            "columnNames": [
+              "receipt_id",
+              "index_inside_receipt"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_receipt_item_receipt_id_index_inside_receipt` ON `${TABLE_NAME}` (`receipt_id`, `index_inside_receipt`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "auth_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL DEFAULT 0, `platform` TEXT NOT NULL, `state` TEXT NOT NULL, PRIMARY KEY(`id`, `platform`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "platform"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "wbw_member",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `full_name` TEXT NOT NULL, `nickname` TEXT NOT NULL, `avatar_url` TEXT, `list_id` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "full_name",
+            "columnName": "full_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatar_url",
+            "columnName": "avatar_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "list_id",
+            "columnName": "list_id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "wbw_list",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `image_url` TEXT, `our_member_id` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image_url",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "our_member_id",
+            "columnName": "our_member_id",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9572833fcc7d943513978228390cb67c')"
+    ]
+  }
+}

--- a/app/schemas/zip.zaop.paylink.database.ReceiptsDatabase/11.json
+++ b/app/schemas/zip.zaop.paylink.database.ReceiptsDatabase/11.json
@@ -1,0 +1,278 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 11,
+    "identityHash": "9572833fcc7d943513978228390cb67c",
+    "entities": [
+      {
+        "tableName": "receipt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `store_provided_id` TEXT NOT NULL, `account_id` INTEGER NOT NULL DEFAULT 0, `date` TEXT NOT NULL, `store` TEXT NOT NULL, `total_amount` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeProvidedId",
+            "columnName": "store_provided_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "account_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "store",
+            "columnName": "store",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalAmount",
+            "columnName": "total_amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_receipt_store_store_provided_id",
+            "unique": true,
+            "columnNames": [
+              "store",
+              "store_provided_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_receipt_store_store_provided_id` ON `${TABLE_NAME}` (`store`, `store_provided_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "receipt_item",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`item_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `index_inside_receipt` INTEGER NOT NULL, `receipt_id` INTEGER NOT NULL, `unit_price` INTEGER NOT NULL, `quantity` REAL NOT NULL, `store_provided_item_code` TEXT, `description` TEXT NOT NULL, `total_price` INTEGER NOT NULL, `total_discount` INTEGER NOT NULL DEFAULT 0, `has_been_sent_to_wbw` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "item_id",
+            "columnName": "item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "indexInsideReceipt",
+            "columnName": "index_inside_receipt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receiptId",
+            "columnName": "receipt_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitPrice",
+            "columnName": "unit_price",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quantity",
+            "columnName": "quantity",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeProvidedItemCode",
+            "columnName": "store_provided_item_code",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPrice",
+            "columnName": "total_price",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalDiscount",
+            "columnName": "total_discount",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hasBeenSentToWbw",
+            "columnName": "has_been_sent_to_wbw",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "item_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_receipt_item_receipt_id_index_inside_receipt",
+            "unique": true,
+            "columnNames": [
+              "receipt_id",
+              "index_inside_receipt"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_receipt_item_receipt_id_index_inside_receipt` ON `${TABLE_NAME}` (`receipt_id`, `index_inside_receipt`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "auth_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL DEFAULT 0, `platform` TEXT NOT NULL, `state` TEXT NOT NULL, PRIMARY KEY(`id`, `platform`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "platform"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "wbw_member",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `full_name` TEXT NOT NULL, `nickname` TEXT NOT NULL, `avatar_url` TEXT, `list_id` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "full_name",
+            "columnName": "full_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatar_url",
+            "columnName": "avatar_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "list_id",
+            "columnName": "list_id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "wbw_list",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `image_url` TEXT, `our_member_id` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image_url",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "our_member_id",
+            "columnName": "our_member_id",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9572833fcc7d943513978228390cb67c')"
+    ]
+  }
+}

--- a/app/schemas/zip.zaop.paylink.database.ReceiptsDatabase/9.json
+++ b/app/schemas/zip.zaop.paylink.database.ReceiptsDatabase/9.json
@@ -1,0 +1,278 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "9572833fcc7d943513978228390cb67c",
+    "entities": [
+      {
+        "tableName": "receipt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `store_provided_id` TEXT NOT NULL, `account_id` INTEGER NOT NULL DEFAULT 0, `date` TEXT NOT NULL, `store` TEXT NOT NULL, `total_amount` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeProvidedId",
+            "columnName": "store_provided_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "account_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "store",
+            "columnName": "store",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalAmount",
+            "columnName": "total_amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_receipt_store_store_provided_id",
+            "unique": true,
+            "columnNames": [
+              "store",
+              "store_provided_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_receipt_store_store_provided_id` ON `${TABLE_NAME}` (`store`, `store_provided_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "receipt_item",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`item_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `index_inside_receipt` INTEGER NOT NULL, `receipt_id` INTEGER NOT NULL, `unit_price` INTEGER NOT NULL, `quantity` REAL NOT NULL, `store_provided_item_code` TEXT, `description` TEXT NOT NULL, `total_price` INTEGER NOT NULL, `total_discount` INTEGER NOT NULL DEFAULT 0, `has_been_sent_to_wbw` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "item_id",
+            "columnName": "item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "indexInsideReceipt",
+            "columnName": "index_inside_receipt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receiptId",
+            "columnName": "receipt_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitPrice",
+            "columnName": "unit_price",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quantity",
+            "columnName": "quantity",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeProvidedItemCode",
+            "columnName": "store_provided_item_code",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPrice",
+            "columnName": "total_price",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalDiscount",
+            "columnName": "total_discount",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hasBeenSentToWbw",
+            "columnName": "has_been_sent_to_wbw",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "item_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_receipt_item_receipt_id_index_inside_receipt",
+            "unique": true,
+            "columnNames": [
+              "receipt_id",
+              "index_inside_receipt"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_receipt_item_receipt_id_index_inside_receipt` ON `${TABLE_NAME}` (`receipt_id`, `index_inside_receipt`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "auth_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL DEFAULT 0, `platform` TEXT NOT NULL, `state` TEXT NOT NULL, PRIMARY KEY(`id`, `platform`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "platform"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "wbw_member",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `full_name` TEXT NOT NULL, `nickname` TEXT NOT NULL, `avatar_url` TEXT, `list_id` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "full_name",
+            "columnName": "full_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatar_url",
+            "columnName": "avatar_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "list_id",
+            "columnName": "list_id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "wbw_list",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `image_url` TEXT, `our_member_id` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image_url",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "our_member_id",
+            "columnName": "our_member_id",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9572833fcc7d943513978228390cb67c')"
+    ]
+  }
+}

--- a/app/src/main/java/zip/zaop/paylink/BonnetjesViewModel.kt
+++ b/app/src/main/java/zip/zaop/paylink/BonnetjesViewModel.kt
@@ -7,6 +7,7 @@ import androidx.annotation.MainThread
 import androidx.annotation.WorkerThread
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -14,7 +15,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import net.openid.appauth.AppAuthConfiguration
 import net.openid.appauth.AuthorizationException
 import net.openid.appauth.AuthorizationResponse
@@ -24,6 +27,9 @@ import net.openid.appauth.ClientSecretBasic
 import net.openid.appauth.TokenRequest
 import net.openid.appauth.TokenResponse
 import net.openid.appauth.connectivity.DefaultConnectionBuilder
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import org.json.JSONObject
+import zip.zaop.paylink.database.DatabaseAuthState
 import zip.zaop.paylink.database.DatabaseWbwMember
 import zip.zaop.paylink.database.LinkablePlatform
 import zip.zaop.paylink.database.getDatabase
@@ -37,6 +43,7 @@ import zip.zaop.paylink.network.ShareMeta
 import zip.zaop.paylink.network.WbwApi
 import zip.zaop.paylink.repository.ReceiptRepository
 import zip.zaop.paylink.util.convertCentsToString
+import java.util.Base64
 import java.util.UUID
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -68,36 +75,64 @@ private const val TAG = "BonnetjesViewModel"
 class BonnetjesViewModel(private val application: Application) : AndroidViewModel(application) {
     private var mExecutor: ExecutorService? = null
     private var mAuthServices: MutableMap<LinkablePlatform, AuthorizationService> = mutableMapOf()
-    private var mStateManagers: MutableMap<LinkablePlatform, AuthStateManager> = mutableMapOf()
 
     private val receiptRepository = ReceiptRepository(getDatabase(application), application)
+    private val authStatesFlow = receiptRepository.authStates
+    private val handledStates = mutableSetOf<String>()
 
     fun closeAlertDialog() {
         _uiState.value = _uiState.value.copy(alertInfo = null)
     }
 
     fun getAllBonnetjes() {
-        for ((platform, stateManager) in mStateManagers.entries) {
-            if (stateManager.current.isAuthorized)
-                getBonnetjes(platform)
+        viewModelScope.launch {
+            authStatesFlow.take(1).collect { map ->
+                for ((platform, states) in map) {
+                    if (platform == LinkablePlatform.WBW) {
+                        continue
+                    }
+                    for (state in states) {
+                        val manager = AuthStateManager.getInstance(
+                            application.applicationContext,
+                            receiptRepository,
+                            platform,
+                            state.id
+                        )
+                        Log.i(TAG, "Fetching receipts for platform: $platform, account ID: ${state.id}")
+                        if (manager.current.isAuthorized) {
+                            Log.i(TAG, "It is authorised")
+                            getBonnetjes(state)
+                        }
+                    }
+                }
+            }
         }
     }
 
-    private fun getBonnetjes(platform: LinkablePlatform) {
+    private fun getBonnetjes(state: DatabaseAuthState) {
+        val platform = state.platform
         _uiState.value = _uiState.value.copy(status = "downloading...")
+        val manager = AuthStateManager.getInstance(
+            application.applicationContext,
+            receiptRepository,
+            platform,
+            state.id
+        )
         if (platform == LinkablePlatform.LIDL) {
             val clientAuthentication: ClientAuthentication = ClientSecretBasic("secret")
-            mStateManagers[platform]!!.current.performActionWithFreshTokens(
+            manager.current.performActionWithFreshTokens(
                 mAuthServices[platform]!!,
                 clientAuthentication,
             ) { accessToken: String?, _idToken: String?, ex: AuthorizationException? ->
-                this.getBonnetjes(platform, accessToken, ex)
+                viewModelScope.launch { manager.replace(manager.current) }
+                this.getBonnetjes(state, accessToken, ex)
             }
         } else {
-            mStateManagers[platform]!!.current.performActionWithFreshTokens(
+            manager.current.performActionWithFreshTokens(
                 mAuthServices[platform]!!
             ) { accessToken: String?, _idToken: String?, ex: AuthorizationException? ->
-                this.getBonnetjes(platform, accessToken, ex)
+                viewModelScope.launch { manager.replace(manager.current) }
+                this.getBonnetjes(state, accessToken, ex)
             }
         }
     }
@@ -274,7 +309,7 @@ class BonnetjesViewModel(private val application: Application) : AndroidViewMode
 
     @MainThread
     fun getBonnetjes(
-        platform: LinkablePlatform,
+        state: DatabaseAuthState,
         accessToken: String?,
         ex: AuthorizationException?
     ) {
@@ -288,7 +323,7 @@ class BonnetjesViewModel(private val application: Application) : AndroidViewMode
 
         viewModelScope.launch {
             try {
-                receiptRepository.refreshReceipts(platform, accessToken!!)
+                receiptRepository.refreshReceipts(state, accessToken!!)
                 _uiState.value = _uiState.value.copy(status = "done")
             } catch (networkError: Exception) {
                 Log.e(TAG, "NETWORK ERROR! $networkError")
@@ -297,12 +332,29 @@ class BonnetjesViewModel(private val application: Application) : AndroidViewMode
         }
     }
 
-    fun fetchReceiptInfo(platform: LinkablePlatform, receipt: Receipt) {
-        val clientAuthentication: ClientAuthentication = ClientSecretBasic("secret")
-        mStateManagers[platform]!!.current.performActionWithFreshTokens(
-            mAuthServices[platform]!!, clientAuthentication
-        ) { accessToken: String?, _idToken: String?, ex: AuthorizationException? ->
-            fetchReceiptInfo(accessToken, ex, receipt)
+    fun fetchReceiptInfo(platform: LinkablePlatform, accountId: Long, receipt: Receipt) {
+        val manager = AuthStateManager.getInstance(
+            application.applicationContext,
+            receiptRepository,
+            platform,
+            accountId
+        )
+        if (platform == LinkablePlatform.LIDL) {
+            val clientAuthentication: ClientAuthentication = ClientSecretBasic("secret")
+            manager.current.performActionWithFreshTokens(
+                mAuthServices[platform]!!,
+                clientAuthentication
+            ) { accessToken: String?, _idToken: String?, ex: AuthorizationException? ->
+                viewModelScope.launch { manager.replace(manager.current) }
+                fetchReceiptInfo(accessToken, ex, receipt)
+            }
+        } else {
+            manager.current.performActionWithFreshTokens(
+                mAuthServices[platform]!!
+            ) { accessToken: String?, _idToken: String?, ex: AuthorizationException? ->
+                viewModelScope.launch { manager.replace(manager.current) }
+                fetchReceiptInfo(accessToken, ex, receipt)
+            }
         }
     }
 
@@ -334,13 +386,6 @@ class BonnetjesViewModel(private val application: Application) : AndroidViewMode
     init {
         val context = application.applicationContext
 
-        mStateManagers[LinkablePlatform.LIDL] =
-            AuthStateManager.getInstance(context, receiptRepository, LinkablePlatform.LIDL)
-        mStateManagers[LinkablePlatform.APPIE] =
-            AuthStateManager.getInstance(context, receiptRepository, LinkablePlatform.APPIE)
-        mStateManagers[LinkablePlatform.JUMBO] =
-            AuthStateManager.getInstance(context, receiptRepository, LinkablePlatform.JUMBO)
-
         mAuthServices[LinkablePlatform.LIDL] = AuthorizationService(
             context,
             AppAuthConfiguration.Builder()
@@ -364,6 +409,7 @@ class BonnetjesViewModel(private val application: Application) : AndroidViewMode
     }
 
     fun start(intent: Intent) {
+        Log.i(TAG, "Starting BonnetjesViewModel with intent: $intent")
         if (mExecutor == null || mExecutor!!.isShutdown) {
             mExecutor = Executors.newSingleThreadExecutor()
         }
@@ -373,6 +419,13 @@ class BonnetjesViewModel(private val application: Application) : AndroidViewMode
         val response = AuthorizationResponse.fromIntent(intent)
         val ex = AuthorizationException.fromIntent(intent)
         if (response != null) {
+            val state = response.request.state
+            if (state == null || handledStates.contains(state)) {
+                Log.i(TAG, "Authorization response already handled or no state, ignoring. State: $state")
+                return
+            }
+            handledStates.add(state)
+
             val platform =
                 when (response.request.clientId) {
                     "appie" -> LinkablePlatform.APPIE
@@ -384,29 +437,85 @@ class BonnetjesViewModel(private val application: Application) : AndroidViewMode
                     }
                 }
 
-            if (mStateManagers[platform]!!.current.isAuthorized) {
-                _uiState.value = _uiState.value.copy(status = "logged in")
-                return
-            }
-
-            Log.i(TAG, "response: " + response.toString() + " ; ex=" + ex.toString())
-
             viewModelScope.launch {
-                mStateManagers[platform]!!.updateAfterAuthorization(response, ex)
-            }
+                Log.i(TAG, "Running viewModelScope launch for platform: $platform")
+                val manager = AuthStateManager.getInstance(
+                    application.applicationContext,
+                    receiptRepository,
+                    platform,
+                    0 // temp ID
+                )
+                manager.updateAfterAuthorization(response, ex)
 
-            if (response.authorizationCode != null) {
-                // authorization code exchange is required
-                Log.i(TAG, "Auth code exchange is required.")
-                exchangeAuthorizationCode(platform, response) // the good stuff :)
-            } else if (ex != null) {
-                displayNotAuthorized("Authorization flow failed: " + ex.message)
-            } else {
-                displayNotAuthorized("No authorization state retained - reauthorization required")
+                if (response.authorizationCode != null) {
+                    // authorization code exchange is required
+                    Log.i(TAG, "Auth code exchange is required.")
+                    exchangeAuthorizationCode(platform, 0, response)
+                } else if (ex != null) {
+                    displayNotAuthorized("Authorization flow failed: " + ex.message)
+                } else {
+                    displayNotAuthorized("No authorization state retained - reauthorization required")
+                }
             }
         }
     }
 
+    fun fetchLidlMemberId(token: String): Long? {
+        val parts = token.split(".")
+        if (parts.size < 2) {
+            Log.e(TAG, "Invalid Lidl JWT")
+            return null
+        }
+        val payloadBase64 = parts[1]
+
+        val decoder = Base64.getUrlDecoder()
+        val payloadJson = String(decoder.decode(payloadBase64))
+
+        val json = JSONObject(payloadJson)
+        val sub = json.optString("sub")
+        val subInt = sub.toLongOrNull()
+
+        return subInt
+    }
+
+    suspend fun fetchAppieMemberId(token: String): Long? {
+        return withContext(Dispatchers.IO) {
+            val client = okhttp3.OkHttpClient()
+            val mediaType = "application/json".toMediaTypeOrNull()
+            val body = okhttp3.RequestBody.create(
+                mediaType, """
+            {
+                "operationName": "GetMember",
+                "variables": {},
+                "query": "query GetMember { member { __typename ...MemberData } }   fragment PersonalDetails on Member { name { first last } }  fragment MemberData on Member { __typename id ...PersonalDetails }"
+            }
+            """.trimIndent()
+            )
+            val request = okhttp3.Request.Builder()
+                .url("https://api.ah.nl/graphql")
+                .post(body)
+                .addHeader("Content-Type", "application/json")
+                .addHeader("Authorization", "Bearer $token")
+                .build()
+
+            return@withContext try {
+                val response = client.newCall(request).execute()
+                val responseBody = response.body?.string()
+                if (response.isSuccessful && responseBody != null) {
+                    val json = JSONObject(responseBody)
+                    json.optJSONObject("data")
+                        ?.optJSONObject("member")
+                        ?.optLong("id")
+                } else {
+                    Log.e(TAG, "Failed to fetch AH member ID: ${responseBody}")
+                    null
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error fetching AH member ID: $e")
+                null
+            }
+        }
+    }
 
     private fun displayNotAuthorized(eep: String) {
         _uiState.value = _uiState.value.copy(status = "not authorized... $eep")
@@ -424,15 +533,18 @@ class BonnetjesViewModel(private val application: Application) : AndroidViewMode
     @MainThread
     private fun exchangeAuthorizationCode(
         platform: LinkablePlatform,
+        accountId: Long,
         authorizationResponse: AuthorizationResponse
     ) {
         displayLoading("Exchanging authorization code")
+        Log.i(TAG, "Exchanging authorization code for platform: $platform, account ID: $accountId")
         performTokenRequest(
             platform,
             authorizationResponse.createTokenExchangeRequest()
         ) { tokenResponse: TokenResponse?, authException: AuthorizationException? ->
             handleCodeExchangeResponse(
                 platform,
+                accountId,
                 tokenResponse,
                 authException
             )
@@ -460,34 +572,70 @@ class BonnetjesViewModel(private val application: Application) : AndroidViewMode
         }
     }
 
+    // TODO: unused?
     @WorkerThread
     private fun handleAccessTokenResponse(
         platform: LinkablePlatform,
         tokenResponse: TokenResponse?,
         authException: AuthorizationException?
     ) {
+        val manager = AuthStateManager.getInstance(
+            application.applicationContext,
+            receiptRepository,
+            platform,
+            0
+        )
         viewModelScope.launch {
-            mStateManagers[platform]!!.updateAfterTokenResponse(tokenResponse, authException)
+            manager.updateAfterTokenResponse(tokenResponse, authException)
         }
     }
 
     @WorkerThread
     private fun handleCodeExchangeResponse(
         platform: LinkablePlatform,
+        accountId: Long,
         tokenResponse: TokenResponse?,
-        authException: AuthorizationException?
+        authException: AuthorizationException?,
     ) {
+        Log.i(TAG, "Handling code exchange response: $tokenResponse, $authException")
+        val tempManager = AuthStateManager.getInstance(
+            application.applicationContext,
+            receiptRepository,
+            platform,
+            accountId
+        )
         viewModelScope.launch {
-            mStateManagers[platform]!!.updateAfterTokenResponse(tokenResponse, authException)
-        }
-        if (!mStateManagers[platform]!!.current.isAuthorized) {
-            val message = ("Authorization Code exchange failed"
-                    + if (authException != null) authException.error else "")
-
-            // WrongThread inference is incorrect for lambdas
-            displayNotAuthorized(message)
-        } else {
-            displayAuthorized(":D")
+            tempManager.updateAfterTokenResponse(tokenResponse, authException)
+            if (!tempManager.current.isAuthorized) {
+                val message = ("Authorization Code exchange failed "
+                        + if (authException != null) authException.error else "")
+                displayNotAuthorized(message)
+            } else {
+                displayAuthorized(":D")
+                val memberId = when (platform) {
+                    LinkablePlatform.LIDL -> fetchLidlMemberId(tempManager.current.accessToken!!)
+                    LinkablePlatform.JUMBO -> TODO()
+                    LinkablePlatform.APPIE -> fetchAppieMemberId(tempManager.current.accessToken!!)
+                    LinkablePlatform.WBW -> 0 // Wbw doesn't use this auth flow
+                }
+                if (memberId != null) {
+                    val finalManager = AuthStateManager.getInstance(
+                        application.applicationContext,
+                        receiptRepository,
+                        platform,
+                        memberId
+                    )
+                    finalManager.replace(tempManager.current)
+                    if (accountId == 0.toLong()) {
+                        tempManager.delete()
+                    }
+                } else {
+                    Log.e(TAG, "Could not fetch member ID.")
+                    if (accountId == 0.toLong()) {
+                        tempManager.delete()
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/zip/zaop/paylink/database/DatabaseEntities.kt
+++ b/app/src/main/java/zip/zaop/paylink/database/DatabaseEntities.kt
@@ -13,6 +13,8 @@ data class DatabaseReceipt constructor(
     val id: Int, // unique database ID
     @ColumnInfo(name = "store_provided_id")
     val storeProvidedId: String,
+    @ColumnInfo(name = "account_id", defaultValue = "0")
+    val accountId: Long,
     val date: String,
     val store: String, // todo ... yeah. for now: "ah", "lidl"
     @ColumnInfo(name = "total_amount")
@@ -41,9 +43,10 @@ data class DatabaseReceiptItem constructor(
     val hasBeenSentToWbw: Boolean,
 )
 
-@Entity(tableName="auth_state")
+@Entity(tableName = "auth_state", primaryKeys = ["id", "platform"])
 data class DatabaseAuthState constructor(
-    @PrimaryKey
+    @ColumnInfo(defaultValue = "0")
+    val id: Long,
     val platform: LinkablePlatform, // ah, lidl, wbw, etc.
     val state: String, // JSON :-)
 )
@@ -76,6 +79,7 @@ fun Map<DatabaseReceipt, List<DatabaseReceiptItem>>.asDomainModel(): List<Receip
         Receipt(
             id = entry.key.id,
             store = entry.key.store,
+            accountId = entry.key.accountId,
             storeProvidedId = entry.key.storeProvidedId,
             date = entry.key.date,
             totalAmount = entry.key.totalAmount,
@@ -93,3 +97,4 @@ fun Map<DatabaseReceipt, List<DatabaseReceiptItem>>.asDomainModel(): List<Receip
         )
     }
 }
+

--- a/app/src/main/java/zip/zaop/paylink/domain/Models.kt
+++ b/app/src/main/java/zip/zaop/paylink/domain/Models.kt
@@ -3,6 +3,7 @@ package zip.zaop.paylink.domain
 data class Receipt(
     val id: Int,
     val items: List<ReceiptItem>?,
+    val accountId: Long,
     val store: String,
     val date: String,
     val totalAmount: Int, // CENTS

--- a/app/src/main/java/zip/zaop/paylink/network/AppieApiDefs.kt
+++ b/app/src/main/java/zip/zaop/paylink/network/AppieApiDefs.kt
@@ -77,10 +77,11 @@ data class AppieReceiptItem(
     val price: String?, // used for total, also for "price per unit" if product is by weight or quantity > 1
 )
 
-fun List<AppieReceiptListItem>.asDatabaseModel(): List<DatabaseReceipt> {
+fun List<AppieReceiptListItem>.asDatabaseModel(accountId: Long, _compileDummy: Boolean = true): List<DatabaseReceipt> {
     return this.map {
         DatabaseReceipt(
             id = 0,
+            accountId = accountId,
             store = "appie",
             date = it.transactionMoment,
             storeProvidedId = it.transactionId,

--- a/app/src/main/java/zip/zaop/paylink/network/JumboApiDefs.kt
+++ b/app/src/main/java/zip/zaop/paylink/network/JumboApiDefs.kt
@@ -67,10 +67,11 @@ fun convertTimestamp(timestamp: String): String {
     return utcTimestamp.toString()
 }
 
-fun List<JumboReceiptListItem>.asDatabaseModel(): List<DatabaseReceipt> {
+fun List<JumboReceiptListItem>.asDatabaseModel(accountId: Long): List<DatabaseReceipt> {
     return this.map {
         DatabaseReceipt(
             id = 0,
+            accountId = accountId,
             store = "jumbo",
             date = convertTimestamp(it.purchaseEndOn),
             storeProvidedId = it.transactionId,

--- a/app/src/main/java/zip/zaop/paylink/network/LidlApiDefs.kt
+++ b/app/src/main/java/zip/zaop/paylink/network/LidlApiDefs.kt
@@ -18,10 +18,11 @@ data class NetworkLidlReceiptList(
     val tickets: List<NetworkLidlReceiptListItem>
 )
 
-fun NetworkLidlReceiptList.asDatabaseModel(): List<DatabaseReceipt> {
+fun NetworkLidlReceiptList.asDatabaseModel(accountId: Long): List<DatabaseReceipt> {
     return tickets.map {
         DatabaseReceipt(
             id = 0,
+            accountId = accountId,
             store = "lidl",
             date = it.date,
             storeProvidedId = it.id,
@@ -74,10 +75,10 @@ fun NetworkLidlReceiptDetails.asDatabaseModel(receiptId: Int): List<DatabaseRece
             XmlPullParser.TEXT -> {
                 if (candidateAttributes != null) {
                     val text = parser.text.trim()
-                    val descriptionAttr = candidateAttributes!!["data-art-description"]
+                    val descriptionAttr = candidateAttributes["data-art-description"]
 
                     if (text.isNotEmpty() && descriptionAttr?.startsWith(text) == true) {
-                        val newArticle = buildItemFromAttributes(candidateAttributes!!, receiptId)
+                        val newArticle = buildItemFromAttributes(candidateAttributes, receiptId)
 
                         if (newArticle != null) {
                             if (currentArticle != null) {


### PR DESCRIPTION
resolves #3 

- enable linking multiple accounts of the same store
- fix issue where old invalidated albert heijn refresh tokens would be used

todo: automatically clean temporary 'id 0' account if new connection flow is canceled